### PR TITLE
Removing unused line that messes up YAML support

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -3,7 +3,6 @@ var RefParser = require('json-schema-ref-parser');
 
 module.exports = function(source) {
   var callback = this.async();
-  var jsonObj = typeof source === 'string' ? JSON.parse(source) : source;
   var parser = new RefParser();
   this.cacheable && this.cacheable();
 


### PR DESCRIPTION
RefParser also supports YAML but that json parse line was hosing it. Since that object isn't used I assumed it was extraneous and removed it.